### PR TITLE
Fix: propType object syntax corrected in Card and Ideas Classes

### DIFF
--- a/src/Card.js
+++ b/src/Card.js
@@ -12,7 +12,7 @@ const Card = ({ title, description, id, removeIdea, isFavorited }) => {
   )
 }
 
-Card.proptypes = {
+Card.propTypes = {
   title: PropTypes.string.isRequired,
   description: PropTypes.string.isRequired,
   id: PropTypes.number.isRequired,

--- a/src/Ideas.js
+++ b/src/Ideas.js
@@ -24,7 +24,7 @@ const Ideas = ({ideas, removeIdea}) => {
   )
 }
 
-Ideas.proptypes = {
+Ideas.propTypes = {
   ideas: PropTypes.array.isRequired,
   removeIdea: PropTypes.func.isRequired
 }


### PR DESCRIPTION
When I went to run the application, I was getting errors that the syntax of `propType` was incorrect, and the app wouldn't load. I forked and corrected and that fixed it, so I wanted to push the changes!